### PR TITLE
fix checkref excluding irc:// links

### DIFF
--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -464,19 +464,19 @@ copy_asciidoc_files:
 checkref: checkref_en checkref_fr checkref_es checkref_vi checkref_zh_CN
 
 checkref_en: $(DOC_TARGETS_HTML_EN) $(DOC_DIR)/html/index.html $(DOC_DIR)/html/gcode.html .htmldoc-stamp
-	@$(DOC_SRCDIR)/checkref -X 'irc://.*' English $^
+	@$(DOC_SRCDIR)/checkref English $^
 
 checkref_fr: $(DOC_TARGETS_HTML_FR) $(DOC_DIR)/html/gcode_fr.html .htmldoc-stamp
-	@$(DOC_SRCDIR)/checkref -X 'irc://.*' French $^
+	@$(DOC_SRCDIR)/checkref French $^
 
 checkref_es: $(DOC_TARGETS_HTML_ES) $(DOC_DIR)/html/gcode_es.html .htmldoc-stamp
-	@$(DOC_SRCDIR)/checkref -X 'irc://.*' Spanish $^
+	@$(DOC_SRCDIR)/checkref Spanish $^
 
 checkref_zh_CN: $(DOC_TARGETS_HTML_ZH_CN) .htmldoc-stamp
-	@$(DOC_SRCDIR)/checkref -X 'irc://.*' Chinese $^
+	@$(DOC_SRCDIR)/checkref Chinese $^
 
 checkref_vi: $(DOC_TARGETS_HTML_VI) $(DOC_DIR)/html/gcode_vi.html .htmldoc-stamp
-	@$(DOC_SRCDIR)/checkref -X 'irc://.*' Vietnamese $^
+	@$(DOC_SRCDIR)/checkref Vietnamese $^
 
 MAN_SRCS_NOSO = $(patsubst $(DOC_DIR)/man/%,%, \
 			$(shell grep -L '^\.so ' $(sort $(MAN_SRCS))))

--- a/docs/src/checkref
+++ b/docs/src/checkref
@@ -22,7 +22,7 @@ BAD_LINKS=0
 for F in $FILES; do
     OUT=.checklink.$LANGUAGE.$(basename $F).tmp
     rm -f $OUT
-    linuxcnc-checklink --quiet --exclude "http(s?)://" $F | tee $OUT 2>&1
+    linuxcnc-checklink --quiet --exclude "(http|https|irc)://" $F  2>&1 | tee $OUT
     egrep -q 'List of (broken links and other issues|duplicate and empty anchors)' $OUT
     if [ $? -ne 1 ]; then
         BAD_LINKS=1


### PR DESCRIPTION
This fixes the checkref thing in our overly convoluted HTML validation system :-/